### PR TITLE
chore: generate updated package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9641,6 +9641,11 @@
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
       "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
     },
+    "immer": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.7.tgz",
+      "integrity": "sha512-KGllzpbamZDvOIxnmJ0jI840g7Oikx58lBPWV0hUh7dtAyZpFqqrBZdKka5GlTwMTZ1Tjc/bKKW4VSFAt6BqMA=="
+    },
     "import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -12747,9 +12752,9 @@
           }
         },
         "trim-newlines": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.0.2.tgz",
-          "integrity": "sha512-GJtWyq9InR/2HRiLZgpIKv+ufIKrVrvjQWEj7PxAXNc5dwbNJkqhAUoAGgzRmULAnoOM5EIpveYd3J2VeSAIew==",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+          "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
           "dev": true,
           "optional": true
         }
@@ -14797,9 +14802,9 @@
           "dev": true
         },
         "immer": {
-          "version": "9.0.7",
-          "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.7.tgz",
-          "integrity": "sha512-KGllzpbamZDvOIxnmJ0jI840g7Oikx58lBPWV0hUh7dtAyZpFqqrBZdKka5GlTwMTZ1Tjc/bKKW4VSFAt6BqMA==",
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.1.tgz",
+          "integrity": "sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==",
           "dev": true
         },
         "loader-utils": {
@@ -17532,6 +17537,11 @@
       "requires": {
         "punycode": "^2.1.1"
       }
+    },
+    "trim-newlines": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.0.2.tgz",
+      "integrity": "sha512-GJtWyq9InR/2HRiLZgpIKv+ufIKrVrvjQWEj7PxAXNc5dwbNJkqhAUoAGgzRmULAnoOM5EIpveYd3J2VeSAIew=="
     },
     "trim-repeated": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9641,10 +9641,6 @@
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
       "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
     },
-    "immer": {
-      "version": ">=9.0.6",
-      "dev": true
-    },
     "import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -12650,7 +12646,7 @@
         "object-assign": "^4.0.1",
         "read-pkg-up": "^1.0.1",
         "redent": "^1.0.0",
-        "trim-newlines": ">=3.0.1"
+        "trim-newlines": "^1.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -12751,7 +12747,11 @@
           }
         },
         "trim-newlines": {
-          "version": ">=3.0.1"
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.0.2.tgz",
+          "integrity": "sha512-GJtWyq9InR/2HRiLZgpIKv+ufIKrVrvjQWEj7PxAXNc5dwbNJkqhAUoAGgzRmULAnoOM5EIpveYd3J2VeSAIew==",
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -14709,7 +14709,7 @@
         "global-modules": "2.0.0",
         "globby": "11.0.1",
         "gzip-size": "5.1.1",
-        "immer": ">=9.0.6",
+        "immer": "8.0.1",
         "is-root": "2.1.0",
         "loader-utils": "2.0.0",
         "open": "^7.0.2",
@@ -14797,7 +14797,10 @@
           "dev": true
         },
         "immer": {
-          "version": ">=9.0.6"
+          "version": "9.0.7",
+          "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.7.tgz",
+          "integrity": "sha512-KGllzpbamZDvOIxnmJ0jI840g7Oikx58lBPWV0hUh7dtAyZpFqqrBZdKka5GlTwMTZ1Tjc/bKKW4VSFAt6BqMA==",
+          "dev": true
         },
         "loader-utils": {
           "version": "2.0.0",
@@ -17529,10 +17532,6 @@
       "requires": {
         "punycode": "^2.1.1"
       }
-    },
-    "trim-newlines": {
-      "version": ">=3.0.1",
-      "dev": true
     },
     "trim-repeated": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "babel-polyfill": "^6.26.0",
     "classnames": "^2.3.1",
     "form-urlencoded": "^6.0.5",
+    "immer": "^9.0.7",
     "lodash.camelcase": "^4.3.0",
     "lodash.snakecase": "^4.1.1",
     "lodash.without": "^4.4.0",
@@ -61,6 +62,7 @@
     "redux-saga-routines": "^3.2.3",
     "redux-thunk": "^2.4.1",
     "reselect": "^4.1.5",
+    "trim-newlines": "^4.0.2",
     "universal-cookie": "^4.0.4"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description
One of the ecommerce e2e tests started failing after the changes [here](https://github.com/edx/frontend-app-payment/commit/dbe08559f884cfc0324b72a3e89b4ae887d87f7f). (test_verified_seat_payment_with_credit_card_payment_page, see [REV-2493](https://openedx.atlassian.net/browse/REV-2493))

Among the clues in the jenkins failure [output](https://tools-edx-jenkins.edx.org/job/e2e/job/stage-ecommerce/2160/artifact/log/assets/test_payment.py__TestSeatPayment__test_verified_seat_payment_with_credit_card_payment_page_4_0.txt), we have: 
https://payment.stage.edx.org/runtime.40a476df247dc6f4ae1e.js 0:1426 Uncaught ReferenceError: globalThis is not defined

The failing js file is [here](https://payment.stage.edx.org/194.8a673d045e382b5be175.js)
^David Joy noted some strangeness in this file; _Something odd is going on with the build.  Other MFEs have a variable named self at the beginning of these sorts of files… this one has globalThis_

The linked PR upgrades to frontend-build v7 (a significant upgrade, that pulled in multiple major version bumps of dependent packages)- this can play hell on a package-lock.json and cause it to structure itself in a way that produces odd results. 

He recommends blowing it away and regenerating it. 


--
_Brief background: node_modules uses child node_modules directories to hold dependencies that don’t match the major version at the top level.  If a package-lock.json changes slowly over time with many breaking changes, this can cause newer versions of dependencies to be relegated to sub-directories, meaning they don’t get used when the should.  That means the build process may have run using some outdated dev dependencies.
Which can have very undefined results… maybe even something like this, I’m guessing._ 



This PR: I ran npm install and it generated an updated package-lock.json file


## Supporting information
<!--
Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.
-->

## Testing instructions
<!--
Please provide detailed step-by-step instructions for testing this change; how did YOU test this change?
-->

## Other information
<!-- 
Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, OpenEdx vs. edx.org differences, development vs. production environment differences, security, or accessibility.
-->

## Checklist
- [x] Consider PCI compliance impact and whether this PR changes how credit card information is handled.
- [x] Intend to [release and monitor](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories) this PR promptly after merge.
