### PR TITLE
chore: updated package-lock.json a la phil workaround

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9641,10 +9641,6 @@
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
       "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
     },
-    "immer": {
-      "version": ">=9.0.6",
-      "dev": true
-    },
     "import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -12751,7 +12747,8 @@
           }
         },
         "trim-newlines": {
-          "version": ">=3.0.1"
+          "version": ">=3.0.1",
+          "dev": true
         }
       }
     },
@@ -14797,7 +14794,8 @@
           "dev": true
         },
         "immer": {
-          "version": ">=9.0.6"
+          "version": ">=9.0.6",
+          "dev": true
         },
         "loader-utils": {
           "version": "2.0.0",
@@ -17529,10 +17527,6 @@
       "requires": {
         "punycode": "^2.1.1"
       }
-    },
-    "trim-newlines": {
-      "version": ">=3.0.1",
-      "dev": true
     },
     "trim-repeated": {
       "version": "1.0.0",


### PR DESCRIPTION
**Description**
One of the ecommerce e2e tests started failing after the changes [here](https://github.com/edx/frontend-app-payment/commit/dbe08559f884cfc0324b72a3e89b4ae887d87f7f). (test_verified_seat_payment_with_credit_card_payment_page, see REV-2493)

Among the clues in the jenkins failure output, we have:
https://payment.stage.edx.org/runtime.40a476df247dc6f4ae1e.js 0:1426 Uncaught ReferenceError: globalThis is not defined

The failing js file is [here](https://payment.stage.edx.org/194.8a673d045e382b5be175.js)
^David Joy noted some strangeness in this file; Something odd is going on with the build. Other MFEs have a variable named self at the beginning of these sorts of files… this one has globalThis

The linked PR upgrades to frontend-build v7 (a significant upgrade, that pulled in multiple major version bumps of dependent packages)- this can play hell on a package-lock.json and cause it to structure itself in a way that produces odd results.

He recommends blowing it away and regenerating it.

--
Brief background: node_modules uses child node_modules directories to hold dependencies that don’t match the major version at the top level. If a package-lock.json changes slowly over time with many breaking changes, this can cause newer versions of dependencies to be relegated to sub-directories, meaning they don’t get used when the should. That means the build process may have run using some outdated dev dependencies.
Which can have very undefined results… maybe even something like this, I’m guessing.

**Change in this PR:** 
I re-generated the package-lock.json using the same workaround that Phil had needed in his earlier update- these are the steps (in local branch): 
run npm audit to get the 'before' state (1 'high' result, for ansi-html package, not used in prod) 
rm -rf node_modules
add resolutions section to package.json, with  "immer": ">=9.0.6", "trim-newlines": ">=3.0.1"
npm install
npx npm-force-resolutions. (output: npx: installed 6 in 1.47s)
'git status' to see an updated package-lock.json file
npm audit to see the 'after' state (no change)
Commit the new package-lock.json (and not package.json)

