### PR TITLE
fix: convert CODEOWNERS to @openedx and add self-check

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,3 @@
 # PCI compliance requires stricter scrutiny, see PR template
-/src	@edx/revenue-squad
+/src	@openedx/revenue-squad
+CODEOWNERS  @openedx/revenue-squad


### PR DESCRIPTION
## Description

Currently, our CODEOWNERS file may not be working because the group `@edx/revenue-squad` no longer exists.

This PR corrects `@edx/revenue-squad` to `@openedx/revenue-squad`.

It also adds the CODEOWNERS file itself as a file requiring approval from @openedx/revenue-squad.

## Additional Information

* Jira: [REV-2707](https://openedx.atlassian.net/browse/REV-2707)