### PR TITLE
Revert "Revert "Revert "fix: Edit HtmlWebpackPlugin for New Relic snippet from frontend-build (#593)" (#594)

### DIFF
--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -1,35 +1,53 @@
+const path = require('path');
+const { mergeWithCustomize, unique } = require('webpack-merge');
 const { getBaseConfig } = require('@edx/frontend-build');
 // NOTE: This version of html-webpack-plugin must be the same major version as the one in
 // frontend-build to avoid potential issues.
+const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 /**
- * This plugin configuration edits the default in webpack-prod for the following reasons:
+ * This plugin configuration overrides the default in webpack-prod for the following reasons:
  *
  * We need to have a custom html-webpack-plugin configuration to allow us to preconnect to
  * various domains.  See the public/index.html file for the companion usage of this configuration.
  */
 
-const config = getBaseConfig('webpack-prod');
+const config = mergeWithCustomize({
+  customizeArray: unique(
+    'plugins',
+    ['HtmlWebpackPlugin'],
+    plugin => plugin.constructor && plugin.constructor.name,
+  ),
+})(
+  getBaseConfig('webpack-prod'),
+  {
+    plugins: [
+      // Generates an HTML file in the output directory.
+      new HtmlWebpackPlugin({
+        inject: false, // Manually inject head and body tags in the template itself.
+        template: path.resolve(__dirname, 'public/index.html'),
+        FAVICON_URL: process.env.FAVICON_URL || null,
+        OPTIMIZELY_PROJECT_ID: process.env.OPTIMIZELY_PROJECT_ID || null,
+        preconnect: (() => {
+          const preconnectDomains = [
+            'https://api.segment.io',
+            'https://cdn.segment.com',
+            'https://www.google-analytics.com',
+          ];
 
-/* eslint-disable no-param-reassign */
-config.plugins.forEach((plugin) => {
-  if (plugin.constructor.name === 'HtmlWebpackPlugin') {
-    const preconnectDomains = [
-      'https://api.segment.io',
-      'https://cdn.segment.com',
-      'https://www.google-analytics.com',
-    ];
+          if (process.env.LMS_BASE_URL) {
+            preconnectDomains.push(process.env.LMS_BASE_URL);
+          }
 
-    if (process.env.LMS_BASE_URL) {
-      preconnectDomains.push(process.env.LMS_BASE_URL);
-    }
+          if (process.env.OPTIMIZELY_PROJECT_ID) {
+            preconnectDomains.push('https://logx.optimizely.com');
+          }
 
-    if (process.env.OPTIMIZELY_PROJECT_ID) {
-      preconnectDomains.push('https://logx.optimizely.com');
-    }
-
-    plugin.userOptions.preconnect = preconnectDomains;
-  }
-});
+          return preconnectDomains;
+        })(),
+      }),
+    ],
+  },
+);
 
 module.exports = config;


### PR DESCRIPTION
## Description
This reverts commit ca0ff1140cc18b98abba6809f6e5abaf4d39d439.

As it turns out, this commit is the actual culprit. It is double-loading <script>s, which triggers a bug further downstream in our project. However, this still introduces a bug, so backing out this code.

You can see the issue on stage in the screenshot below. Note the <script> tags with the same source.

<img width="1920" alt="stage_with-new-webpack" src="https://user-images.githubusercontent.com/3790674/190732400-af40d238-cc3c-49b0-a0d7-a0c8be006e1a.png">

## Supporting information
* Jira: [REV-2674](https://2u-internal.atlassian.net/browse/REV-2674)

## Testing instructions

* Local
  * [X] Run test payment
* Stage
  * [ ] Run test payment
* Prod
  * [ ] Run test payment

## Checklist
- [X] Consider PCI compliance impact and whether this PR changes how credit card information is handled.
- [X] Intend to [release and monitor](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories) this PR promptly after merge.
