### PR TITLE
build: Add package-lock file version check

### DIFF
--- a/.github/workflows/lockfileversion-check.yml
+++ b/.github/workflows/lockfileversion-check.yml
@@ -1,0 +1,13 @@
+#check package-lock file version
+
+name: Lockfile Version check
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+
+jobs:
+  version-check:
+    uses: edx/.github/.github/workflows/lockfileversion-check.yml@master


### PR DESCRIPTION
### Description
- This PR replaces https://github.com/openedx/frontend-app-payment/pull/600 to add the package-lock version file check. It has been blocked due to the failures occurring on master so can be merged now.