### PR TITLE
build: retire branch project-zebra CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: node_js CI
 on:
   push:
     branches:
-    - master, project-zebra
+    - master
   pull_request:
     branches:
     - '**'


### PR DESCRIPTION
## Description

Now that we are pushing the Project Zebra code to master, we no longer need the CI to run on that branch.

Partial revert of 95085161fa9a1f84d1e109505baf1a0fb08ed720

## Additional information

* Jira: [REV-3146](https://2u-internal.atlassian.net/browse/REV-3146) Cleanup: Remove project-zebra branch from CI