### PR TITLE
fix: fix transifex pull translations command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ push_translations:
 
 # Pulls translations from Transifex.
 pull_translations:
-	tx pull -f --mode reviewed --languages=$(transifex_langs)
+	tx pull -f -t --mode reviewed --languages=$(transifex_langs)
 
 # This target is used by CI.
 validate-no-uncommitted-package-lock-changes:


### PR DESCRIPTION
### Description

- `Transifex` latest version requires `-t` parameter with the `tx pull` command to work properly.