### PR TITLE
chore: Update audit-ci with vulnerability w breaking change

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -7,7 +7,8 @@
         "GHSA-h452-7996-h45h",
         "GHSA-hhq3-ff78-jv3g",
         "GHSA-pfrx-2q88-qq97",
-        "GHSA-rc47-6667-2j5j"
+        "GHSA-rc47-6667-2j5j",
+        "GHSA-hc6q-2mpp-qw7j"
     ],
     "moderate": true
 }


### PR DESCRIPTION
Unblocking PON-82 for Ponderosa Squad to avoid duplicate work on both `master` and `ponderosa-master` branches.

https://github.com/advisories/GHSA-hc6q-2mpp-qw7j
Upgrading `webpack 5` would install `frontend-build` at v6.1.1 which is a breaking change.