### PR TITLE
chore: Add yaml vulnerability to allowlist to unblock commits

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -8,7 +8,8 @@
         "GHSA-hhq3-ff78-jv3g",
         "GHSA-pfrx-2q88-qq97",
         "GHSA-rc47-6667-2j5j",
-        "GHSA-hc6q-2mpp-qw7j"
+        "GHSA-hc6q-2mpp-qw7j",
+        "GHSA-f9xv-q969-pqx4"
     ],
     "moderate": true
 }


### PR DESCRIPTION
[PON-179](https://2u-internal.atlassian.net/browse/PON-179).

Unblocking Ponderosa folks on making commits on `ponderosa-master` branch.
Added: https://github.com/advisories/GHSA-f9xv-q969-pqx4

Otherwise, we would need to upgrade `yaml` to v2 from v1, major change which according to NPM it's a breaking change.