### PR TITLE
fix: Update allowlist to unblock translations

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -9,7 +9,8 @@
         "GHSA-pfrx-2q88-qq97",
         "GHSA-rc47-6667-2j5j",
         "GHSA-hc6q-2mpp-qw7j",
-        "GHSA-f9xv-q969-pqx4"
+        "GHSA-f9xv-q969-pqx4",
+        "GHSA-c2qf-rxjj-qqgw"
     ],
     "moderate": true
 }


### PR DESCRIPTION
Translations jobs in Jenkins were failing due to the removal of some GitHub groups by Axim (https://tools-edx-jenkins.edx.org/job/translations/job/frontend-app-payment-pull_translations/240/console).

There was a fix on their end, but the translation PR failed https://github.com/openedx/frontend-app-payment/pull/766 due to a security vulnerability on `semver` versions < 7.5.2 which is dependency in various packages we use - 

https://github.com/advisories/GHSA-c2qf-rxjj-qqgw

