### PR TITLE
Updated CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,7 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ env.NODE_VER }}
-    - run: npm install -g npm@${{ matrix.npm }}
-    
+
     - name: Install dependencies
       run: npm ci
 


### PR DESCRIPTION
## Description
Updated `ci` workflow to remove `npm install -g npm@${{ matrix.npm }}` which was rendered unnecessary with shift to `nvmrc` based workflow