### PR TITLE
revert: removed the CSP meta tag

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,6 @@
     <link rel="preconnect" href="<%= preconnectURL %>" />
     <% }); %>
     <title>Payment | edX</title>
-    <meta http-equiv="Content-Security-Policy" content="frame-src 'self' https://js.stripe.com https://hooks.stripe.com;"/>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="shortcut icon" href="<%=htmlWebpackPlugin.options.FAVICON_URL%>" type="image/x-icon" />


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

This PR reverted the change for adding a Content Security Policy meta tag in the index.html. We are going to update the `terraform` CSP headers for payment MFE.