### PR TITLE
fix: Add security advisory to allowlist for adobe/css-tools

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -10,7 +10,8 @@
         "GHSA-rc47-6667-2j5j",
         "GHSA-hc6q-2mpp-qw7j",
         "GHSA-f9xv-q969-pqx4",
-        "GHSA-c2qf-rxjj-qqgw"
+        "GHSA-c2qf-rxjj-qqgw",
+        "GHSA-hpx4-r86g-5jrg"
     ],
     "moderate": true
 }


### PR DESCRIPTION
[REV-3662](https://2u-internal.atlassian.net/browse/REV-3662).

Security advisory for `adobe/css-tools`, version 4.3.0 and earlier are affected. This is a dependency for `@testing-library/jest-dom`, but the latest version has `adobe/css-tools` at version 4.3.0.

Adding to allowlist to unblock any commits for now.
https://github.com/advisories/GHSA-hpx4-r86g-5jrg