### PR TITLE
fix: Clean up allowlist security advisories

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -10,7 +10,6 @@
         "GHSA-rc47-6667-2j5j",
         "GHSA-hc6q-2mpp-qw7j",
         "GHSA-f9xv-q969-pqx4",
-        "GHSA-c2qf-rxjj-qqgw",
         "GHSA-hpx4-r86g-5jrg"
     ],
     "moderate": true

--- a/audit-ci.json
+++ b/audit-ci.json
@@ -1,15 +1,5 @@
 {
     "allowlist": [
-        "GHSA-3rfm-jhwj-7488",
-        "GHSA-44c6-4v22-4mhx",
-        "GHSA-76p3-8jx3-jpfq",
-        "GHSA-9c47-m6qq-7p4h",
-        "GHSA-h452-7996-h45h",
-        "GHSA-hhq3-ff78-jv3g",
-        "GHSA-pfrx-2q88-qq97",
-        "GHSA-rc47-6667-2j5j",
-        "GHSA-hc6q-2mpp-qw7j",
-        "GHSA-f9xv-q969-pqx4",
         "GHSA-hpx4-r86g-5jrg"
     ],
     "moderate": true


### PR DESCRIPTION
[REV-3598](https://2u-internal.atlassian.net/browse/REV-3598).

These GHSA advisories no longer need to be allowlisted.