### PR TITLE
Added paypal button redirect mechanism from ecommerce tools checkout

### DIFF
--- a/src/payment/checkout/Checkout.jsx
+++ b/src/payment/checkout/Checkout.jsx
@@ -157,10 +157,16 @@ class Checkout extends React.Component {
       paymentMethod,
       submitting,
       orderType,
+      isPaypalRedirect,
     } = this.props;
     const submissionDisabled = loading || isBasketProcessing;
     const isBulkOrder = orderType === ORDER_TYPES.BULK_ENROLLMENT;
     const isQuantityUpdating = isBasketProcessing && loaded;
+
+    if (!submissionDisabled && isPaypalRedirect) {
+      // auto submit to paypal since the paypal redirect flag is set in the incoming rquiest
+      this.handleSubmitPayPal();
+    }
 
     // Stripe element config
     // TODO: Move these to a better home
@@ -324,6 +330,7 @@ Checkout.propTypes = {
   orderType: PropTypes.oneOf(Object.values(ORDER_TYPES)),
   enableStripePaymentProcessor: PropTypes.bool,
   clientSecretId: PropTypes.string,
+  isPaypalRedirect: PropTypes.bool,
 };
 
 Checkout.defaultProps = {
@@ -336,6 +343,7 @@ Checkout.defaultProps = {
   orderType: ORDER_TYPES.SEAT,
   enableStripePaymentProcessor: false,
   clientSecretId: null,
+  isPaypalRedirect: false,
 };
 
 const mapStateToProps = (state) => ({

--- a/src/payment/data/selectors.js
+++ b/src/payment/data/selectors.js
@@ -37,9 +37,12 @@ export const paymentSelector = createSelector(
   (basket, queryParams) => {
     const isCouponRedeemRedirect = !!queryParams
       && queryParams.coupon_redeem_redirect == 1; // eslint-disable-line eqeqeq
+    const isPaypalRedirect = !!queryParams
+      && queryParams.paypal_redirect == 1; // eslint-disable-line eqeqeq
     return {
       ...basket,
       isCouponRedeemRedirect,
+      isPaypalRedirect,
       isEmpty:
         basket.loaded && !basket.redirect && (!basket.products || basket.products.length === 0),
       isRedirect:


### PR DESCRIPTION
### Summary
This is intended as a temporary measure to allow users to pay via PayPal, until we implement full PayPal support in the new checkout.

Ticket# (https://2u-internal.atlassian.net/browse/SONIC-501)

### Make sure you get approval for the PR from your internal team first and then from the owning team (Sonic). Drop a message in [#team-sonic-eng](https://twou.slack.com/archives/C065NLHU1NF) or [#project-sonic](https://twou.slack.com/archives/C05Q3ARUZQF) for approval from the owning team. 
### Anyone merging to this repository must ensure the checklist is completed (only for the Checkout project).

---
### Acceptance Criteria

- PayPal button exists in new checkout, mirroring the design of the legacy checkout
- Clicking the PayPal button brings the customer to the legacy checkout
- When arriving at legacy checkout
-- any previously applied coupon is re-applied
-- the PayPal flow is immediately initiated, and the user is brought to PayPal to complete their transaction

- Completing the PayPal transaction results in a successful order and fulfillment in the legacy system

---
### Checklist
- [ ] **ENSURE** that Netlify Environment variables are set to correct values for all environments before merging the PR. Refer to [Updating Environment Variables in Netlify](https://docs.netlify.com/environment-variables/get-started/#update-variables-with-the-netlify-ui)
- [ ] **ENSURE** that Studio configs and variables are set for all environments before merging the PR. Refer to [Setting configs and variables](https://github.com/frontastic-developers/customer-twou/blob/master/packages/checkout/docs/environment-configs-and-variables.md)

⚠️ Failure to follow these steps will result in new environment variables missing in the deployement. Values for environment variables are loaded at build time, Hence we **must ensure** the values are set before the build is triggered and not at deployment time
**NOTE: Prod builds are also auto triggered when PR is merged, not at the time of deployment**

Visit [Sonic Deployments and Rollback Run Book](https://2u-internal.atlassian.net/wiki/spaces/ER/pages/976027725/Sonic+Deployments+and+Rollback+Run+Book) for more information regarding the deployment
