### PR TITLE
chore: test CI with readme only change

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,6 +3,8 @@
 frontend-app-payment
 ====================
 
+TEST
+
 Please tag **@edx/revenue-squad** on any PRs or issues.  Thanks.
 
 Introduction


### PR DESCRIPTION
I noticed CI failures for both Node 18 and 20 on https://github.com/openedx/frontend-app-payment/pull/879, this PR is to verify the errors still appear with a README only change